### PR TITLE
fix: parseJsonToXml used incorrect json path

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 				Usage: "Parses the UAT tools output json into JUnit XML for ci's",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:     "json",
+						Name:     "jsonFile",
 						Aliases:  []string{"j"},
 						Value:    "",
 						Usage:    "Unreal Automation Testing test output json file",

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 						Name:     "json",
 						Aliases:  []string{"j"},
 						Value:    "",
-						Usage:    "UAT test output json file",
+						Usage:    "Unreal Automation Testing test output json file",
 						Required: true,
 					},
 					&cli.StringFlag{
@@ -91,7 +91,7 @@ func main() {
 					&cli.StringFlag{
 						Name:    "testSuiteName",
 						Aliases: []string{"t"},
-						Value:   "Unreal Automation Testing JUnit Test Report",
+						Value:   "Unreal Automation Testing JUnit Report",
 						Usage:   "Test suite name.  Optional",
 					},
 				},

--- a/pkgs/jsonToXml/jsonToXml.go
+++ b/pkgs/jsonToXml/jsonToXml.go
@@ -70,7 +70,7 @@ type TestEvent struct {
 func ParseTestOutput(jsonFilePath string, outPath string, testSuiteName string) error {
 	jsonData, err := ioutil.ReadFile(jsonFilePath)
 	if err != nil {
-		return cli.Exit(fmt.Errorf("error reading json file: %s", err), 1)
+		return cli.Exit(fmt.Errorf("error reading json file: %s, err: %s", jsonFilePath, err), 1)
 	}
 
 	jsonDataWithoutBom, err := ioutil.ReadAll(utfbom.SkipOnly(bytes.NewReader(jsonData)))


### PR DESCRIPTION
The parseJsonToXml command was not parsing the correct parameter resulting in an empty json path variable